### PR TITLE
add redirection from previous /guide/start-here/ to just /guide

### DIFF
--- a/.vuepress/enhanceApp.js
+++ b/.vuepress/enhanceApp.js
@@ -1,0 +1,5 @@
+export default ({ router }) => {
+  router.addRoutes([
+    { path: '/guide/start-here/*', redirect: '/guide/*' },
+  ])
+}


### PR DESCRIPTION
It doesn't work in prod :(

https://5cd40eaf3b08a4000a23de8b--mesg-docs.netlify.com/guide/start-here/quick-start-guide.html

the url change but the page doesn't refresh